### PR TITLE
Improve API Type Safety

### DIFF
--- a/Sources/XCTHealthKit/XCTestCase+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTestCase+HealthApp.swift
@@ -13,8 +13,6 @@ extension XCTestCase {
     /// Exits the system under test and opens the Apple Health app to show the page defined by the passed in ``HealthAppDataType`` instance.
     /// - Parameter healthDataType: The ``HealthAppDataType`` indicating the page in the Apple Health app that should be opened.
     public func exitAppAndOpenHealth(_ healthDataType: HealthAppDataType) throws {
-        XCUIDevice.shared.press(.home)
-        
         addUIInterruptionMonitor(withDescription: "System Dialog") { alert in
             guard alert.buttons["Allow"].exists else {
                 XCTFail("Failed not dismiss alert: \(alert.staticTexts.allElementsBoundByIndex)")
@@ -26,7 +24,6 @@ extension XCTestCase {
         }
         
         let healthApp = XCUIApplication(bundleIdentifier: "com.apple.Health")
-        healthApp.terminate()
         healthApp.activate()
         
         if healthApp.staticTexts["Welcome to Health"].waitForExistence(timeout: 2) {
@@ -39,6 +36,8 @@ extension XCTestCase {
         }
         
         healthApp.tabBars["Tab Bar"].buttons["Browse"].tap()
+        healthApp.tabBars["Tab Bar"].buttons["Browse"].tap()
+        XCTAssert(healthApp.navigationBars.staticTexts["Browse"].waitForExistence(timeout: 10))
         
         try healthDataType.navigateToElement()
         
@@ -59,11 +58,6 @@ extension XCTestCase {
         }
         
         healthApp.navigationBars.firstMatch.buttons["Add"].tap()
-        
-        healthApp.terminate()
-        
-        let testApp = XCUIApplication()
-        testApp.activate()
     }
     
     

--- a/Sources/XCTHealthKit/XCUIApplication+HealthAccess.swift
+++ b/Sources/XCTHealthKit/XCUIApplication+HealthAccess.swift
@@ -23,8 +23,8 @@ extension XCUIApplication {
 
     /// Collects the number of occurences of HealthKit type identifier in the current user interface of the system unter test.
     /// - Returns: Returns a dictionairy containing the HealthKit type identifier as a key and the number of occurences as the value.
-    public func numberOfHKTypeIdentifiers() -> [String: Int] {
-        var observations: [String: Int] = [:]
+    public func numberOfHKTypeIdentifiers() -> [HealthAppDataType: Int] {
+        var observations: [HealthAppDataType: Int] = [:]
         for healthDataType in HealthAppDataType.allCases {
             let numberOfHKTypeNames = self.staticTexts.allElementsBoundByIndex
                 .filter {
@@ -32,7 +32,7 @@ extension XCUIApplication {
                 }
                 .count
             if numberOfHKTypeNames > 0 {
-                observations[healthDataType.hkTypeName] = numberOfHKTypeNames
+                observations[healthDataType] = numberOfHKTypeNames
             }
         }
         return observations

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -35,10 +35,10 @@ class TestAppUITests: XCTestCase {
         XCTAssertEqual(
             app.numberOfHKTypeIdentifiers(),
             [
-                "HKQuantityTypeIdentifierActiveEnergyBurned": 2,
-                "HKQuantityTypeIdentifierRestingHeartRate": 1,
-                "HKDataTypeIdentifierElectrocardiogram": 3,
-                "HKQuantityTypeIdentifierStepCount": 1
+                .activeEnergy: 2,
+                .restingHeartRate: 1,
+                .electrocardiograms: 3,
+                .steps: 1
             ]
         )
     }


### PR DESCRIPTION
# Improve API Surface

## :recycle: Current situation & Problem
The `numberOfHKTypeIdentifiers` API returns an untyped `String` identifier.

## :bulb: Proposed solution
Updates the numberOfHKTypeIdentifiers` API to return a `HealthAppDataType` as the key. 
Also speeds up adding elements to the HealthApp by reducing the times we need to relaunch the Health App.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

