### PR TITLE
Improve Test Stability

### DIFF
--- a/Sources/XCTHealthKit/XCTestCase+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTestCase+HealthApp.swift
@@ -19,16 +19,6 @@ extension XCTestCase {
     
     
     private func exitAppAndOpenHealthThatMightBeRepeated(_ healthDataType: HealthAppDataType, alreadyRecursive: Bool = false) throws {
-        addUIInterruptionMonitor(withDescription: "System Dialog") { alert in
-            guard alert.buttons["Allow"].exists else {
-                XCTFail("Failed not dismiss alert: \(alert.staticTexts.allElementsBoundByIndex)")
-                return false
-            }
-            
-            alert.buttons["Allow"].tap()
-            return true
-        }
-        
         let healthApp = XCUIApplication(bundleIdentifier: "com.apple.Health")
         healthApp.activate()
         
@@ -82,6 +72,16 @@ extension XCTestCase {
     }
     
     private func handleWelcomeToHealth(alreadyRecursive: Bool = false) {
+        addUIInterruptionMonitor(withDescription: "System Dialog") { alert in
+            guard alert.buttons["Allow"].exists else {
+                XCTFail("Failed not dismiss alert: \(alert.staticTexts.allElementsBoundByIndex)")
+                return false
+            }
+            
+            alert.buttons["Allow"].tap()
+            return true
+        }
+        
         let healthApp = XCUIApplication(bundleIdentifier: "com.apple.Health")
         
         if healthApp.staticTexts["Welcome to Health"].waitForExistence(timeout: 5) {
@@ -129,8 +129,6 @@ extension XCTestCase {
             
             XCTAssertTrue(healthApp.staticTexts["Continue"].waitForExistence(timeout: 5))
             healthApp.staticTexts["Continue"].tap()
-            
-            
         }
     }
 }

--- a/Sources/XCTHealthKit/XCTestCase+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTestCase+HealthApp.swift
@@ -27,7 +27,7 @@ extension XCTestCase {
         }
         
         let browseTabBarButton = healthApp.tabBars["Tab Bar"].buttons["Browse"]
-        if !browseTabBarButton.isHittable {
+        if !browseTabBarButton.waitForExistence(timeout: 5) && !browseTabBarButton.isHittable {
             os_log("Failed to find the browse tab bar button: \(healthApp.tabBars["Tab Bar"].buttons)")
             
             let cancelButton = healthApp.navigationBars.firstMatch.buttons["Cancel"]

--- a/Sources/XCTHealthKit/XCTestCase+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTestCase+HealthApp.swift
@@ -69,6 +69,16 @@ extension XCTestCase {
         }
         
         healthApp.navigationBars.firstMatch.buttons["Add"].tap()
+        
+        if !healthApp.navigationBars.firstMatch.buttons["Add Data"].waitForExistence(timeout: 20) {
+            healthApp.terminate()
+            
+            if alreadyRecursive {
+                throw XCTestError(.failureWhileWaiting)
+            } else {
+                try exitAppAndOpenHealthThatMightBeRepeated(healthDataType, alreadyRecursive: true)
+            }
+        }
     }
     
     private func handleWelcomeToHealth(alreadyRecursive: Bool = false) {


### PR DESCRIPTION
# Improve Test Stability

## :recycle: Current situation & Problem
The interaction with the Health App sometimes shows an information view about the Health App that triggers the display of a notification screen which stops the text execution. 

## :bulb: Proposed solution
This PR adds an additional check to disable the notification toggle and adds an other level of retry to the test.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

