### PR TITLE
Fix failing HealthKit tests on iOS17

### DIFF
--- a/Sources/XCTHealthKit/HealthAppDataType.swift
+++ b/Sources/XCTHealthKit/HealthAppDataType.swift
@@ -129,8 +129,8 @@ public enum HealthAppDataType: String, CaseIterable {
             healthApp.tables.textFields["BPM"].tap()
             healthApp.tables.textFields["BPM"].typeText("80")
         case .electrocardiograms:
-            XCTAssert(healthApp.tables.staticTexts["High Heart Rate"].waitForExistence(timeout: 2))
-            healthApp.tables.staticTexts["High Heart Rate"].tap()
+            XCTAssert(healthApp.tables.staticTexts["High Heart Rate"].firstMatch.waitForExistence(timeout: 2))
+            healthApp.tables.staticTexts["High Heart Rate"].firstMatch.tap()
         case .steps:
             XCTAssert(healthApp.tables.textFields["Steps"].waitForExistence(timeout: 2))
             healthApp.tables.textFields["Steps"].tap()

--- a/Tests/UITests/TestApp.xctestplan
+++ b/Tests/UITests/TestApp.xctestplan
@@ -9,6 +9,15 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:..\/..",
+          "identifier" : "XCTHealthKit",
+          "name" : "XCTHealthKit"
+        }
+      ]
+    },
     "targetForVariableExpansion" : {
       "containerPath" : "container:UITests.xcodeproj",
       "identifier" : "2F6D139128F5F384007C25D6",

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.5;
+				minimumVersion = 0.4.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -8,6 +8,20 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCTHealthKit"
+               BuildableName = "XCTHealthKit"
+               BlueprintName = "XCTHealthKit"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Fix failing HealthKit tests on iOS17

## :recycle: Current situation & Problem
As described in StanfordSpezi/SpeziHealthKit#7, `XCTHealthKit` is failing on iOS17 within the `addData()` function as the XCT UI test detects two buttons with the text "`High Heart Rate`" when adding Electrocardiogram test data within HealthKit. As only one of these buttons should exist (and be tapped), the tests are currently failing. 
For more details, see StanfordSpezi/SpeziHealthKit#7 (especially look at the comments as well as the failing CI).

In my testing, this behavior isn't present within HealthKit on iOS16, only on iOS17. Therefore, it could be that this issue is will be resolved in stable iOS17 releases.

| **Intended** "High Heart Rate" button                                                | **Accidentally** detected "High Heart Rate" button                                                |
| ------------------------------------------------------- | ------------------------------------------------------- |
| <img src="https://github.com/StanfordBDHG/XCTHealthKit/assets/25406915/c77c9c2b-15e2-4019-a855-ae3e31085237" alt="Description of Picture 1" style="width:100px;"> | <img src="https://github.com/StanfordBDHG/XCTHealthKit/assets/25406915/5c7d3768-29cc-4d86-982f-0583313ce96d" alt="Description of Picture 2" style="width:100px;"> |

## :bulb: Proposed solution
To differentiate between the two detected "`High Heart Rate`" buttons while adding Electrocardiograms test data, this PR introduces the use of the `firstMatch` property. This functionality enables us to select the button that is on a "higher" level in the view stack (so the one within the popup sheet) which is also the one the UI test intends to use.

## :gear: Release Notes 
- Fixes the UI test functionality that adds Electrocardiogram test data to HealthKit on iOS17

## :heavy_plus_sign: Additional Information
Debugging this error was quite a pain ;)

### Related PRs
https://github.com/StanfordSpezi/SpeziHealthKit/pull/7

### Testing
I tested the adjusted logic locally with Xcode 15 and iOS 17 as well as the CI runners (e.g. https://github.com/StanfordSpezi/SpeziHealthKit/pull/7).

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

