### PR TITLE
try to fix locale issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import XCTHealthKit
 
 class HealthKitUITests: XCTestCase {
     func testAddMockData() throws {
-        let healthApp = XCUIApplication.healthApp()
+        let healthApp = XCUIApplication.healthApp
         try launchAndAddSample(healthApp: healthApp, .steps(value: 71))
         try launchAndAddSample(healthApp: healthApp, .electrocardiogram())
     }
@@ -50,7 +50,7 @@ import XCTHealthKit
 
 class HealthKitUITests: XCTestCase {
     func testAddMockData() throws {
-        let healthApp = XCUIApplication.healthApp()
+        let healthApp = XCUIApplication.healthApp
         try launchAndAddSamples(healthApp: healthApp, [
             .activeEnergy(),
             .electrocardiogram(),

--- a/Sources/XCTHealthKit/XCTHealthKit.docc/XCTHealthKit.md
+++ b/Sources/XCTHealthKit/XCTHealthKit.docc/XCTHealthKit.md
@@ -29,7 +29,7 @@ import XCTHealthKit
 
 class HealthKitUITests: XCTestCase {
     func testAddMockData() throws {
-        let healthApp = XCUIApplication.healthApp()
+        let healthApp = XCUIApplication.healthApp
         try launchAndAddSample(healthApp: healthApp, .steps(value: 71))
         try launchAndAddSample(healthApp: healthApp, .electrocardiogram())
     }
@@ -43,7 +43,7 @@ import XCTHealthKit
 
 class HealthKitUITests: XCTestCase {
     func testAddMockData() throws {
-        let healthApp = XCUIApplication.healthApp()
+        let healthApp = XCUIApplication.healthApp
         try launchAndAddSamples(healthApp: healthApp, [
             .activeEnergy(),
             .electrocardiogram(),

--- a/Sources/XCTHealthKit/XCTHealthKitAddSampleInput.swift
+++ b/Sources/XCTHealthKit/XCTHealthKitAddSampleInput.swift
@@ -88,8 +88,8 @@ extension NewHealthSampleInput {
     }
     
     /// Creates a new Electrocardiogram sample input, with the specified values
-    public static func electrocardiogram(date: DateComponents? = nil) -> Self {
-        .init(sampleType: .electrocardiograms, date: date, enterSampleValueHandler: .custom { _, app in
+    public static func electrocardiogram() -> Self {
+        .init(sampleType: .electrocardiograms, date: nil, enterSampleValueHandler: .custom { _, app in
             XCTAssert(app.tables.staticTexts["High Heart Rate"].firstMatch.waitForExistence(timeout: 2))
             app.tables.staticTexts["High Heart Rate"].firstMatch.tap()
         })

--- a/Sources/XCTHealthKit/XCTest+HealthKit.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthKit.swift
@@ -20,13 +20,8 @@ struct XCTHealthKitError: Error {
 
 extension XCUIApplication {
     /// The Apple Health app
-    public static func healthApp(locale: Locale? = nil) -> XCUIApplication {
-        let app = XCUIApplication(bundleIdentifier: "com.apple.Health")
-        if let locale {
-            app.launchArguments.append("-AppleLocale")
-            app.launchArguments.append(locale.identifier)
-        }
-        return app
+    public static var healthApp: XCUIApplication {
+        XCUIApplication(bundleIdentifier: "com.apple.Health")
     }
 }
 

--- a/Sources/XCTHealthKit/XCTest+HealthKit.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthKit.swift
@@ -20,10 +20,12 @@ struct XCTHealthKitError: Error {
 
 extension XCUIApplication {
     /// The Apple Health app
-    public static func healthApp(locale: Locale = .current) -> XCUIApplication {
+    public static func healthApp(locale: Locale? = nil) -> XCUIApplication {
         let app = XCUIApplication(bundleIdentifier: "com.apple.Health")
-        app.launchArguments.append("-AppleLocale")
-        app.launchArguments.append(locale.identifier)
+        if let locale {
+            app.launchArguments.append("-AppleLocale")
+            app.launchArguments.append(locale.identifier)
+        }
         return app
     }
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -22,7 +22,7 @@ class TestAppUITests: XCTestCase {
     
     @MainActor
     func testXCTHealthKitAddSamples1() throws {
-        let healthApp = XCUIApplication.healthApp()
+        let healthApp = XCUIApplication.healthApp
         try launchAndAddSample(healthApp: healthApp, .electrocardiogram())
         try launchAndAddSample(healthApp: healthApp, .steps())
         healthApp.terminate()
@@ -35,7 +35,7 @@ class TestAppUITests: XCTestCase {
     
     @MainActor
     func testXCTHealthKitAddSamples2() throws {
-        let healthApp = XCUIApplication.healthApp()
+        let healthApp = XCUIApplication.healthApp
         try launchAndAddSamples(healthApp: healthApp, [.electrocardiogram(), .steps()])
         healthApp.terminate()
         try launchAndAddSamples(healthApp: healthApp, [.pushes(), .restingHeartRate()])
@@ -46,7 +46,7 @@ class TestAppUITests: XCTestCase {
     
     @MainActor
     func testSampleEntryWithDateAndTime() throws {
-        try launchAndAddSample(healthApp: .healthApp(), .steps(
+        try launchAndAddSample(healthApp: .healthApp, .steps(
             value: 52,
             date: DateComponents(year: 2025, month: 01, day: 19, hour: 14, minute: 42)
         ))


### PR DESCRIPTION
# try to fix locale issues

## :recycle: Current situation & Problem
In #14, i added the ability to override the Health app's locale, in an attempt to make it easier to test the Health app in a locale-independent manner. (The idea was that you'd be able to simply always specify some fixed locale, which would then be used regardless of where you're running your tests.)
It seems that i flew too close to the sun with this, since it randomly breaks the Health app (even though the approach used was [officially recommended](https://forums.developer.apple.com/forums/thread/678634)), and makes it somehow display only a small subset of all data and catagories.

This PR fixes this, by entirely removing the locale overide.
(The previous version defaulted it to `.current`, which I had assumed would be the same as not overriding it, but that doesn't seem to be the case.)


## :gear: Release Notes 
- Remove `locale` parameter in `XCUIApplication.healthApp(locale:)`; make it a static computed property
- Fix Health app sometimes not displaying all data/categories
- Disallow specifying a date when creating ECG samples


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
