### PR TITLE
improve UITesting reliability

### DIFF
--- a/Sources/XCTHealthKit/XCTest+CharacteristicEntry.swift
+++ b/Sources/XCTHealthKit/XCTest+CharacteristicEntry.swift
@@ -207,7 +207,7 @@ extension XCUIElement {
         if isHittable {
             tap()
         } else {
-            coordinate(withNormalizedOffset: .zero).tap()
+            coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
         }
     }
 }


### PR DESCRIPTION
# improve UITesting reliability

## :recycle: Current situation & Problem
in our workaround needed sometimes to tap buttons that for some reason are reported as being non-hittable (even though we know they are), we now try to tap the middle of the XCUIElement rather than the top-left corner


## :gear: Release Notes 
- improve UITesting reliability

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
