### PR TITLE
try to fix Health app navigation on small devices

### DIFF
--- a/Sources/XCTHealthKit/HealthAppSampleType.swift
+++ b/Sources/XCTHealthKit/HealthAppSampleType.swift
@@ -76,27 +76,18 @@ extension HealthAppSampleType {
         if !assumeAlreadyInCategory {
             try category.navigateToPage(in: healthApp)
         }
-        
         let elementStaticTextPredicate = NSPredicate(format: "label CONTAINS[cd] %@", healthAppDisplayTitle)
         let elementStaticText = healthApp.staticTexts.element(matching: elementStaticTextPredicate).firstMatch
-        
-        guard elementStaticText.waitForExistence(timeout: 30), elementStaticText.isHittable else {
-            healthApp.swipeUp()
+        // depending on the device type and the sample type, we might need to scroll down all the way.
+        for _ in 0..<5 {
             if elementStaticText.waitForExistence(timeout: 10), elementStaticText.isHittable {
                 elementStaticText.tap()
                 return
+            } else {
+                healthApp.swipeUp()
             }
-            
-            healthApp.swipeUp()
-            if elementStaticText.waitForExistence(timeout: 10), elementStaticText.isHittable {
-                elementStaticText.tap()
-                return
-            }
-            
-            logger.notice("Failed to find element in category: \(healthApp.staticTexts.allElementsBoundByIndex)")
-            throw XCTestError(.failureWhileWaiting)
         }
-        
-        elementStaticText.tap()
+        logger.notice("Failed to find element in category: \(healthApp.staticTexts.allElementsBoundByIndex)")
+        throw XCTestError(.failureWhileWaiting)
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.6;
+				minimumVersion = 1.2.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
# try to fix Health app navigation on small devices

## :recycle: Current situation & Problem
when navigating to a sample type's page w/in the Health app, we currently perform a max of 2 scroll down operations. this might not always be enough, e.g. if the test is running on a small device and several sample types in the category have data and are listed as a large cell (that contains a chart) rather than a smaller cell.

instead of performing 2 sequential scoll-down operations, we now have a loop that attempts to locate the sample type, with a limit of 4 scrolls. also, the code isn't duplicated anymore.


## :gear: Release Notes
- fix Health app navigation on small devices 


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
