### PR TITLE
auth timeout control

### DIFF
--- a/Sources/XCTHealthKit/XCTest+HealthKit.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthKit.swift
@@ -50,15 +50,23 @@ extension XCUIApplication {
             throw XCTHealthKitError("App \(bundleIdentifier) is not the Health app!")
         }
     }
-    
-    /// Detects and dismisses the HealthKit Authorization sheet. Fails if the sheet is not displayed.
-    public func handleHealthKitAuthorization() throws {
-        if !self.navigationBars["Health Access"].waitForExistence(timeout: 10) {
-            logger.notice("The HealthKit View did not load after 10 seconds ... give it a second try with a timeout of 20 seconds.")
-        }
-        if self.navigationBars["Health Access"].waitForExistence(timeout: 20) {
+}
+
+
+extension XCUIApplication {
+    /// Detects and dismisses the HealthKit Authorization sheet.
+    ///
+    /// - parameter timeout: how long the function should wait for the sheet to appear.
+    /// - parameter requireSheetToAppear: Whether the function should require the sheet to appear, i.e. whether it should fail if no Health permissions sheet is presented within the `timeout`.
+    public func handleHealthKitAuthorization(
+        timeout: TimeInterval = 5,
+        requireSheetToAppear: Bool = false
+    ) {
+        if self.navigationBars["Health Access"].waitForExistence(timeout: timeout) {
             self.tables.staticTexts["Turn On All"].tap()
             self.navigationBars["Health Access"].buttons["Allow"].tap()
+        } else if requireSheetToAppear {
+            XCTFail("No Health permissions sheet appeared within the timeout (\(timeout) sec)")
         }
     }
 }

--- a/Sources/XCTHealthKit/XCTest+HealthKit.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthKit.swift
@@ -59,7 +59,7 @@ extension XCUIApplication {
     /// - parameter timeout: how long the function should wait for the sheet to appear.
     /// - parameter requireSheetToAppear: Whether the function should require the sheet to appear, i.e. whether it should fail if no Health permissions sheet is presented within the `timeout`.
     public func handleHealthKitAuthorization(
-        timeout: TimeInterval = 15,
+        timeout: TimeInterval = 20,
         requireSheetToAppear: Bool = false
     ) {
         if self.navigationBars["Health Access"].waitForExistence(timeout: timeout) {

--- a/Sources/XCTHealthKit/XCTest+HealthKit.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthKit.swift
@@ -59,7 +59,7 @@ extension XCUIApplication {
     /// - parameter timeout: how long the function should wait for the sheet to appear.
     /// - parameter requireSheetToAppear: Whether the function should require the sheet to appear, i.e. whether it should fail if no Health permissions sheet is presented within the `timeout`.
     public func handleHealthKitAuthorization(
-        timeout: TimeInterval = 5,
+        timeout: TimeInterval = 15,
         requireSheetToAppear: Bool = false
     ) {
         if self.navigationBars["Health Access"].waitForExistence(timeout: timeout) {


### PR DESCRIPTION
# auth timeout control

## :recycle: Current situation & Problem
- currently, the `handleHealthKitAuthorization` function will always wait for up to 30 seconds for the HealthKit auth sheet to appear, and there is no way for the caller to control this timeout
- the docs of the function say "Fails if the sheet is not displayed", which is not true since the function never fails if the sheet is not displayed

this PR addresses both of these issues, by:
- adding 2 (optional) parameters, for controlling the timeout and whether the function should fail if the sheet doesn't appear within the timeout. (there are cases where a UI test can't be sure if the app will require re-authorization or if it's already authorized, meaning that we can't make it unconditionally fail if the sheet doesn't appear)
- the new `requireSheetToAppear` param defaults to false; this is the opposite of the function's previous documented behaviour, but it matches its previous actual behaviour.
- the new `timeout` param defaults to 20 seconds, which is 2/3 the previous max waiting time, but should work fine. if an app needs to, it can override this with a longer timeout.
- reworking the logic to no longer use two separate waits


## :gear: Release Notes
- reworked `XCUIApplication.handleHealthKitAuthorization` to allow the caller to control timeout and failure behaviour.


## :books: Documentation
yes

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
