### PR TITLE
Additional Notifications Checks

### DIFF
--- a/Sources/XCTHealthKit/XCTHealthKitAddSampleInput.swift
+++ b/Sources/XCTHealthKit/XCTHealthKitAddSampleInput.swift
@@ -160,7 +160,8 @@ extension XCUIApplication {
             return
         }
         
-        self.tables.staticTexts["Date"].tap() // present the data picker
+        // present the date picker
+        self.buttons["Date Picker"].coordinate(withNormalizedOffset: .init(dx: 0.9, dy: 0.5)).tap()
         
         let monthAndYearButton = app.buttons.matching(NSPredicate(format: "label LIKE[cd] %@", "month")).firstMatch
         if !monthAndYearButton.waitForExistence(timeout: 2) {
@@ -200,13 +201,13 @@ extension XCUIApplication {
             }
         }
         if let day = components.day {
-            let button = app.tables["UIA.Health.AddData.View"].cells["UIA.Health.AddData.DateCell"].staticTexts[String(day)]
+            let button = app.staticTexts[String(day)]
             if !button.waitForExistence(timeout: 1) {
                 XCTFail("Unable to find button to select day.")
             }
             button.tap()
         }
-        self.tables.staticTexts["Date"].tap() // dismiss the date picker
+        self.buttons["dismiss popup"].tap() // dismiss the date picker
     }
     
     
@@ -215,7 +216,10 @@ extension XCUIApplication {
             // there is nothing to be done
             return
         }
-        self.tables.staticTexts["Time"].tap() // present the time picker
+        
+        // present the time picker
+        self.buttons["Time Picker"].coordinate(withNormalizedOffset: .init(dx: 0.9, dy: 0.5)).tap()
+        
         XCTAssert(app.pickerWheels.firstMatch.waitForExistence(timeout: 1))
         let pickerWheels = app.pickers.firstMatch.pickerWheels.allElementsBoundByIndex
         if let hour = components.hour {
@@ -233,7 +237,7 @@ extension XCUIApplication {
         if let minute = components.minute {
             pickerWheels[1].adjust(toPickerWheelValue: String(format: "%02lld", minute))
         }
-        self.tables.staticTexts["Time"].tap() // dismiss the time picker
+        self.buttons["dismiss popup"].tap() // dismiss the time picker
     }
 }
 
@@ -246,11 +250,17 @@ extension XCUIElement {
     
     static func extractMonthAndYearComponents(_ input: String) -> (month: (value: Int, name: String), year: Int)? {
         let components = input.split(separator: " ")
+        
+        guard components.count == 2 else {
+            return nil
+        }
+        
         let monthText = String(components[0])
         guard let monthValue = Self.monthValue(for: monthText),
               let year = Int(components[1]) else {
             return nil
         }
+        
         return (month: (value: monthValue + 1, name: monthText), year: year)
     }
     

--- a/Sources/XCTHealthKit/XCTest+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthApp.swift
@@ -68,7 +68,7 @@ extension XCTestCase {
             XCTAssertTrue(healthApp.staticTexts["Continue"].waitForExistence(timeout: 5))
             healthApp.staticTexts["Continue"].tap()
             
-            // Unfortunately it seems like the general notifications dialog triggerd as the function exists
+            // Unfortunately it seems like the general notifications dialog triggered as the function exits
             // which triggers the UInterruptionMonitor but then exits this function too early and calls `removeUIInterruptionMonitor`.
             // Therefore, we manually wait here for a bit.
             sleep(5)

--- a/Sources/XCTHealthKit/XCTest+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthApp.swift
@@ -67,6 +67,14 @@ extension XCTestCase {
             
             XCTAssertTrue(healthApp.staticTexts["Continue"].waitForExistence(timeout: 5))
             healthApp.staticTexts["Continue"].tap()
+            
+            // Unfortunately it seems like the general notifications dialog triggerd as the function exists
+            // which doesn't trigger the IInterruptionMonitor or just exits too early.
+            // We manually also check for it's existance:
+            let notificationsAllowButton = healthApp.alerts.buttons["Allow"]
+            if notificationsAllowButton.waitForExistence(timeout: 1) {
+                notificationsAllowButton.tap()
+            }
         }
     }
     

--- a/Sources/XCTHealthKit/XCTest+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthApp.swift
@@ -68,10 +68,12 @@ extension XCTestCase {
             XCTAssertTrue(healthApp.staticTexts["Continue"].waitForExistence(timeout: 5))
             healthApp.staticTexts["Continue"].tap()
             
-            // Unfortunately it seems like the general notifications dialog triggered as the function exits
-            // which triggers the UInterruptionMonitor but then exits this function too early and calls `removeUIInterruptionMonitor`.
-            // Therefore, we manually wait here for a bit.
-            sleep(5)
+            // Unfortunately it seems like the UInterruptionMonitor does not catch the alert here.
+            // Therefore, we have to manually see if it shows up here ...
+            let allowNotificationsButton = XCUIApplication(bundleIdentifier: "com.apple.springboard").alerts.buttons["Allow"]
+            if allowNotificationsButton.waitForExistence(timeout: 5) {
+                allowNotificationsButton.tap()
+            }
         }
         
         removeUIInterruptionMonitor(monitor)

--- a/Sources/XCTHealthKit/XCTest+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthApp.swift
@@ -70,11 +70,8 @@ extension XCTestCase {
             
             // Unfortunately it seems like the general notifications dialog triggerd as the function exists
             // which triggers the UInterruptionMonitor but then exits this function too early and calls `removeUIInterruptionMonitor`.
-            // Therefore, we manually wait a bit here (even though it won't appear in the UI hierachy).
-            let notificationsAllowButton = healthApp.alerts.buttons["Allow"]
-            if notificationsAllowButton.waitForExistence(timeout: 5) {
-                notificationsAllowButton.tap()
-            }
+            // Therefore, we manually wait here for a bit.
+            sleep(5)
         }
         
         removeUIInterruptionMonitor(monitor)

--- a/Sources/XCTHealthKit/XCTest+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthApp.swift
@@ -69,10 +69,10 @@ extension XCTestCase {
             healthApp.staticTexts["Continue"].tap()
             
             // Unfortunately it seems like the general notifications dialog triggerd as the function exists
-            // which doesn't trigger the UInterruptionMonitor or just exits too early.
-            // We manually therefore wait for a second (even though it won't appear in the UI hierachy).
+            // which triggers the UInterruptionMonitor but then exits this function too early and calls `removeUIInterruptionMonitor`.
+            // Therefore, we manually wait a bit here (even though it won't appear in the UI hierachy).
             let notificationsAllowButton = healthApp.alerts.buttons["Allow"]
-            if notificationsAllowButton.waitForExistence(timeout: 1) {
+            if notificationsAllowButton.waitForExistence(timeout: 5) {
                 notificationsAllowButton.tap()
             }
         }

--- a/Sources/XCTHealthKit/XCTest+HealthApp.swift
+++ b/Sources/XCTHealthKit/XCTest+HealthApp.swift
@@ -86,8 +86,14 @@ extension XCTestCase {
     public func installHealthAppNotificationsAlertMonitor() -> any NSObjectProtocol {
         self.addUIInterruptionMonitor(withDescription: "System Dialog") { alert in
             MainActor.assumeIsolated {
-                guard alert.title.matches(/.*Helath.*/) else {
+                guard alert.staticTexts["“Health” Would Like to Send You Notifications"].exists else {
                     // Not the Health app's Notification request alert.
+                    print(
+                        """
+                        Got an UIInterruptionMonitor alert that is not from the Health App:
+                        \(alert.staticTexts)
+                        """
+                    )
                     return false
                 }
                 guard alert.buttons["Allow"].exists else {
@@ -98,12 +104,5 @@ extension XCTestCase {
                 return true
             }
         }
-    }
-}
-
-
-extension String {
-    func matches(_ regex: some RegexComponent) -> Bool {
-        self.firstMatch(of: regex) != nil
     }
 }


### PR DESCRIPTION
# Additional Notifications Checks

## :recycle: Current situation & Problem
- The notification alert is sometimes not caught in later iOS 26+ versions.

## :gear: Release Notes
- Additional Notifications Checks

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
