### PR TITLE
fix characteristics entry

### DIFF
--- a/Sources/XCTHealthKit/XCTest+CharacteristicEntry.swift
+++ b/Sources/XCTHealthKit/XCTest+CharacteristicEntry.swift
@@ -65,8 +65,12 @@ extension XCTestCase {
         healthApp.launch()
         handleHealthAppOnboardingIfNecessary()
         
-        XCTAssert(healthApp.buttons["Profile"].waitForExistence(timeout: 2))
-        healthApp.buttons["Profile"].tryToTapReallySoftlyMaybeThisWillMakeItWork()
+        let profileButton = healthApp.buttons["Profile"]
+        if !profileButton.waitForExistence(timeout: 2) {
+            healthApp.tabBars.buttons["Summary"].tap()
+        }
+        XCTAssert(profileButton.waitForExistence(timeout: 2))
+        profileButton.tryToTapReallySoftlyMaybeThisWillMakeItWork()
         sleep(1) // wait a second to make sure the sheet has fully appeared
         healthApp.cells["Health Details"].tap()
         sleep(1) // wait a second to make sure the "Health Details" view has been presented.

--- a/Sources/XCTHealthKit/XCTest+CharacteristicEntry.swift
+++ b/Sources/XCTHealthKit/XCTest+CharacteristicEntry.swift
@@ -63,12 +63,12 @@ extension XCTestCase {
     ) throws {
         let healthApp = XCUIApplication.healthApp
         healthApp.launch()
+        healthApp.terminate()
+        healthApp.launch()
         handleHealthAppOnboardingIfNecessary()
         
+        healthApp.tabBars.buttons["Summary"].tap() // make sure we're on the first tab
         let profileButton = healthApp.buttons["Profile"]
-        if !profileButton.waitForExistence(timeout: 2) {
-            healthApp.tabBars.buttons["Summary"].tap()
-        }
         XCTAssert(profileButton.waitForExistence(timeout: 2))
         profileButton.tryToTapReallySoftlyMaybeThisWillMakeItWork()
         sleep(1) // wait a second to make sure the sheet has fully appeared


### PR DESCRIPTION
# fix characteristics entry

## :recycle: Current situation & Problem
characteristics entry fails if the Health app was in a tab other than the first when it was last used before the call.
this PR fixed this, by adding logic to make sure we're on the first tab before we attempt to navigate to the characteristics sheet.


## :gear: Release Notes
- fix characteristics entry


## :books: Documentation
n/a


## :white_check_mark: Testing
as best we can


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
